### PR TITLE
fix(github): close all fork PRs on manual dispatch

### DIFF
--- a/.github/workflows/handle-forks.yml
+++ b/.github/workflows/handle-forks.yml
@@ -4,17 +4,12 @@ on:
   pull_request_target:
     types: [opened, synchronize]
   workflow_dispatch:
-    inputs:
-      pr_number:
-        description: PR number to close
-        required: true
-        type: number
 
 
 jobs:
   close-fork-pr:
     if: ${{
-        github.event_name == 'workflow_dispatch' 
+        github.event_name == 'workflow_dispatch'
         ||
         github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
       }}
@@ -29,20 +24,37 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const prNumber = context.eventName === 'workflow_dispatch'
-              ? Number(context.payload.inputs.pr_number)
-              : context.payload.pull_request.number;
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: "Please create a new PR and choose your fork as the base repo. You've made a PR to the instructors' repo."
-            });
+            async function closeForkPr(prNumber) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: "Please create a new PR and choose your fork as the base repo. You've made a PR to the instructors' repo."
+              });
 
-            await github.rest.pulls.update({
-              owner,
-              repo,
-              pull_number: prNumber,
-              state: 'closed'
-            });
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+            }
+
+            if (context.eventName === 'workflow_dispatch') {
+              const pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+              });
+
+              const forkPrs = pulls.filter(
+                pr => pr.head.repo.full_name !== pr.base.repo.full_name
+              );
+
+              for (const pr of forkPrs) {
+                await closeForkPr(pr.number);
+              }
+            } else {
+              await closeForkPr(context.payload.pull_request.number);
+            }


### PR DESCRIPTION
## Summary

- Remove pr_number input; fetch and filter all open fork PRs instead
- Extract close logic into helper to reuse across both trigger paths

---

## Checklist

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch>` above the PR title.
- [x] I edited the line `- Closes #<issue-number>`.
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I'm submitting.