### PR TITLE
feat: implement analytics endpoints (scores, pass-rates, timeline, gr…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
 
   // Change the Primary Sidebar location
 
-  "workbench.sideBar.location": "right",
+  "workbench.sideBar.location": "left",
 
   // Markdown settings
 

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -1,16 +1,36 @@
-"""Router for analytics endpoints.
-
-Each endpoint performs SQL aggregation queries on the interaction data
-populated by the ETL pipeline. All endpoints require a `lab` query
-parameter to filter results by lab (e.g., "lab-01").
-"""
-
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import case, func
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.database import get_session
+from app.models.interaction import InteractionLog
+from app.models.item import ItemRecord
+from app.models.learner import Learner
 
 router = APIRouter()
+
+
+async def _get_lab_and_task_ids(lab: str, session: AsyncSession) -> tuple[ItemRecord | None, list[int]]:
+    """Helper: найти lab item и его task children по lab identifier."""
+    lab_title_part = lab.replace("lab-", "Lab ")
+
+    lab_stmt = select(ItemRecord).where(
+        ItemRecord.type == "lab",
+        ItemRecord.title.contains(lab_title_part),
+    )
+    lab_item = (await session.exec(lab_stmt)).first()
+
+    if lab_item is None:
+        return None, []
+
+    task_stmt = select(ItemRecord.id).where(
+        ItemRecord.type == "task",
+        ItemRecord.parent_id == lab_item.id,
+    )
+    task_ids = list((await session.exec(task_stmt)).all())
+
+    return lab_item, task_ids
 
 
 @router.get("/scores")
@@ -18,19 +38,40 @@ async def get_scores(
     lab: str = Query(..., description="Lab identifier, e.g. 'lab-01'"),
     session: AsyncSession = Depends(get_session),
 ):
-    """Score distribution histogram for a given lab.
+    lab_item, task_ids = await _get_lab_and_task_ids(lab, session)
+    if lab_item is None or not task_ids:
+        return [
+            {"bucket": "0-25", "count": 0},
+            {"bucket": "26-50", "count": 0},
+            {"bucket": "51-75", "count": 0},
+            {"bucket": "76-100", "count": 0},
+        ]
 
-    TODO: Implement this endpoint.
-    - Find the lab item by matching title (e.g. "lab-04" → title contains "Lab 04")
-    - Find all tasks that belong to this lab (parent_id = lab.id)
-    - Query interactions for these items that have a score
-    - Group scores into buckets: "0-25", "26-50", "51-75", "76-100"
-      using CASE WHEN expressions
-    - Return a JSON array:
-      [{"bucket": "0-25", "count": 12}, {"bucket": "26-50", "count": 8}, ...]
-    - Always return all four buckets, even if count is 0
-    """
-    raise NotImplementedError
+    bucket_expr = case(
+        (InteractionLog.score <= 25, "0-25"),
+        (InteractionLog.score <= 50, "26-50"),
+        (InteractionLog.score <= 75, "51-75"),
+        else_="76-100",
+    ).label("bucket")
+
+    stmt = (
+        select(bucket_expr, func.count().label("count"))
+        .where(
+            InteractionLog.item_id.in_(task_ids),
+            InteractionLog.score.is_not(None),
+        )
+        .group_by(bucket_expr)
+    )
+
+    rows = (await session.exec(stmt)).all()
+    data = {bucket: count for bucket, count in rows}
+
+    return [
+        {"bucket": "0-25", "count": data.get("0-25", 0)},
+        {"bucket": "26-50", "count": data.get("26-50", 0)},
+        {"bucket": "51-75", "count": data.get("51-75", 0)},
+        {"bucket": "76-100", "count": data.get("76-100", 0)},
+    ]
 
 
 @router.get("/pass-rates")
@@ -38,18 +79,35 @@ async def get_pass_rates(
     lab: str = Query(..., description="Lab identifier, e.g. 'lab-01'"),
     session: AsyncSession = Depends(get_session),
 ):
-    """Per-task pass rates for a given lab.
+    lab_item, task_ids = await _get_lab_and_task_ids(lab, session)
+    if lab_item is None or not task_ids:
+        return []
 
-    TODO: Implement this endpoint.
-    - Find the lab item and its child task items
-    - For each task, compute:
-      - avg_score: average of interaction scores (round to 1 decimal)
-      - attempts: total number of interactions
-    - Return a JSON array:
-      [{"task": "Repository Setup", "avg_score": 92.3, "attempts": 150}, ...]
-    - Order by task title
-    """
-    raise NotImplementedError
+    stmt = (
+        select(
+            ItemRecord.title.label("task"),
+            func.round(func.avg(InteractionLog.score), 1).label("avg_score"),
+            func.count(InteractionLog.id).label("attempts"),
+        )
+        .join(InteractionLog, InteractionLog.item_id == ItemRecord.id)
+        .where(
+            ItemRecord.id.in_(task_ids),
+            InteractionLog.score.is_not(None),
+        )
+        .group_by(ItemRecord.id, ItemRecord.title)
+        .order_by(ItemRecord.title)
+    )
+
+    rows = (await session.exec(stmt)).all()
+
+    return [
+        {
+            "task": task,
+            "avg_score": float(avg_score) if avg_score is not None else 0.0,
+            "attempts": attempts,
+        }
+        for task, avg_score, attempts in rows
+    ]
 
 
 @router.get("/timeline")
@@ -57,17 +115,28 @@ async def get_timeline(
     lab: str = Query(..., description="Lab identifier, e.g. 'lab-01'"),
     session: AsyncSession = Depends(get_session),
 ):
-    """Submissions per day for a given lab.
+    lab_item, task_ids = await _get_lab_and_task_ids(lab, session)
+    if lab_item is None or not task_ids:
+        return []
 
-    TODO: Implement this endpoint.
-    - Find the lab item and its child task items
-    - Group interactions by date (use func.date(created_at))
-    - Count the number of submissions per day
-    - Return a JSON array:
-      [{"date": "2026-02-28", "submissions": 45}, ...]
-    - Order by date ascending
-    """
-    raise NotImplementedError
+    date_expr = func.date(InteractionLog.created_at)
+
+    stmt = (
+        select(
+            date_expr.label("date"),
+            func.count(InteractionLog.id).label("submissions"),
+        )
+        .where(InteractionLog.item_id.in_(task_ids))
+        .group_by(date_expr)
+        .order_by(date_expr)
+    )
+
+    rows = (await session.exec(stmt)).all()
+
+    return [
+        {"date": str(date_value), "submissions": submissions}
+        for date_value, submissions in rows
+    ]
 
 
 @router.get("/groups")
@@ -75,16 +144,32 @@ async def get_groups(
     lab: str = Query(..., description="Lab identifier, e.g. 'lab-01'"),
     session: AsyncSession = Depends(get_session),
 ):
-    """Per-group performance for a given lab.
+    lab_item, task_ids = await _get_lab_and_task_ids(lab, session)
+    if lab_item is None or not task_ids:
+        return []
 
-    TODO: Implement this endpoint.
-    - Find the lab item and its child task items
-    - Join interactions with learners to get student_group
-    - For each group, compute:
-      - avg_score: average score (round to 1 decimal)
-      - students: count of distinct learners
-    - Return a JSON array:
-      [{"group": "B23-CS-01", "avg_score": 78.5, "students": 25}, ...]
-    - Order by group name
-    """
-    raise NotImplementedError
+    stmt = (
+        select(
+            Learner.student_group.label("group"),
+            func.round(func.avg(InteractionLog.score), 1).label("avg_score"),
+            func.count(func.distinct(InteractionLog.learner_id)).label("students"),
+        )
+        .join(Learner, Learner.id == InteractionLog.learner_id)
+        .where(
+            InteractionLog.item_id.in_(task_ids),
+            InteractionLog.score.is_not(None),
+        )
+        .group_by(Learner.student_group)
+        .order_by(Learner.student_group)
+    )
+
+    rows = (await session.exec(stmt)).all()
+
+    return [
+        {
+            "group": group,
+            "avg_score": float(avg_score) if avg_score is not None else 0.0,
+            "students": students,
+        }
+        for group, avg_score, students in rows
+    ]


### PR DESCRIPTION
## Task 2: Analytics Endpoints ✅

Implements 4 analytics endpoints for data visualization:

### Endpoints Implemented
- `GET /analytics/scores?lab=lab-04` - Score distribution by buckets (0-25, 26-50, 51-75, 76-100)
- `GET /analytics/pass-rates?lab=lab-04` - Average score and attempts per task
- `GET /analytics/timeline?lab=lab-04` - Submissions count by date
- `GET /analytics/groups?lab=lab-04` - Performance by student groups

### Testing
- ✅ All 20 unit tests passing (`uv run poe test`)
- ✅ Tested via Swagger UI

### Related Issue
Closes #1